### PR TITLE
Add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
+.PHONY: all test
+
 all:
 	dune build ./main.exe
+
+test:
+	dune exec ./test/test.exe

--- a/opam-zi.opam
+++ b/opam-zi.opam
@@ -19,7 +19,7 @@ dev-repo: "git+https://github.com/talex5/opam-0install-solver.git"
 doc: "https://talex5.github.io/opam-0install-solver/"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "./test/test.exe"] {with-test}
 ]
 depends: [
   "fmt"
@@ -27,4 +27,7 @@ depends: [
   "opam-state"
   "dune" {>= "1.11"}
   "ocaml" {>= "4.8.0"}
+  "opam-client" {with-test}
+  "opam-solver" {with-test}
+  "alcotest" {with-test}
 ]

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(executable
+ (name test)
+ (libraries opam_zi fmt fmt.tty alcotest opam-solver opam-client))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,177 @@
+module Name = OpamPackage.Name
+module Version = OpamPackage.Version
+
+let () =
+  Random.self_init ();
+  Fmt_tty.setup_std_outputs ()
+
+let errors = ref 0
+
+let select_zi st spec =
+  let constraints =
+    spec
+    |> List.filter_map (function
+        | _, None -> None
+        | x, Some y -> Some (x, y)
+      )
+    |> Name.Map.of_list in
+  let context = Opam_zi.create ~constraints st in
+  let pkgs = List.map fst spec in
+  let r = Opam_zi.solve context pkgs in
+  match r with
+  | Ok sels ->
+    let pkgs = Opam_zi.packages_of_result sels in
+    Some (OpamPackage.Set.of_list pkgs)
+  | Error _ -> None
+
+let select_opam st spec =
+  let request = OpamSolver.request ~install:spec () in
+  let names = List.map fst spec |> Name.Set.of_list in
+  match OpamSolution.resolve st Install ~orphans:OpamPackage.Set.empty ~requested:names request with
+  | Success s -> Some (OpamSolver.all_packages s)
+  | Conflicts _ -> None
+
+let string_of_version_opt = function
+  | None -> "-"
+  | Some v -> Version.to_string v
+
+let error fmt =
+  incr errors;
+  Fmt.pr ("%a " ^^ fmt ^^ "@.") Fmt.(styled `Red string) "[ERROR]"
+
+let pp_change f (name, (opam, zi)) =
+  Fmt.pf f "%22s: %14s -> %s@,"
+    (OpamPackage.Name.to_string name)
+    (string_of_version_opt opam)
+    (string_of_version_opt zi)
+
+let pp_diff f diff =
+  diff |> Name.Map.iter (fun name pair ->
+      match pair with
+      | Some opam, Some zi ->
+        if OpamPackage.Version.compare opam zi < 0 then Fmt.(styled `Green pp_change) f (name, pair)
+        else Fmt.(styled `Red pp_change) f (name, pair)
+      | _ -> pp_change f (name, pair)
+    )
+
+let opam_confirms st zi_results =
+  let spec = OpamPackage.Set.to_seq zi_results |> List.of_seq
+             |> List.map (fun { OpamPackage.name; version } ->
+                 (name, Some (`Eq, version))
+               )
+  in
+  select_opam st spec <> None
+
+let compare st ~opam ~zi =
+  match opam, zi with
+  | None, None -> Fmt.pr "Opam and 0install %a.@." Fmt.(styled `Green string) "agree there is no solution";
+  | None, Some zi ->
+    if opam_confirms st zi then
+      Fmt.pr "opam %a, but %a@."
+        Fmt.(styled `Red string) "failed to find a solution"
+        Fmt.(styled `Green string) "accepts 0install's solution as valid"
+    else
+      error "opam failed to find a solution and rejects 0install's solution"
+  | Some _, None ->
+    error "opam found a solution, but 0install didn't!"
+  | Some opam, Some zi ->
+    let module M = Name.Map in
+    let map_of set =
+      let m =
+        set 
+        |> OpamPackage.Set.to_seq
+        |> List.of_seq
+        |> List.map (fun { OpamPackage.name; version } -> (name, version))
+        |> M.of_list
+      in
+      assert (M.cardinal m = OpamPackage.Set.cardinal set);
+      m
+    in
+    let merge _name opam zi =
+      match opam, zi with
+      | Some opam, Some zi when Version.compare opam zi = 0 -> None
+      | _ -> Some (opam, zi)
+    in
+    let diff =
+      let opam = map_of opam in
+      let zi = map_of zi in
+      M.merge merge opam zi
+    in
+    if M.is_empty diff then (
+      Fmt.pr "Opam and 0install results are %a.@." Fmt.(styled `Green string) "identical";
+    ) else (
+      Fmt.pr "@[<v2>%a Opam and 0install results differ:@,%a@]"
+        Fmt.(styled `Blue string) "[NOTE]"
+        pp_diff diff;
+      if not (opam_confirms st zi) then
+        error "opam rejects 0install's solution"
+    )
+
+let test st spec =
+  Fmt.pr "@.== Solving for %a ==@." (Fmt.styled `Bold Fmt.(list ~sep:(unit " ") string)) spec;
+  let spec = spec |> List.map (fun s ->
+      if String.contains s '.' then (
+        let { OpamPackage.name; version } = OpamPackage.of_string s in
+        (name, Some (`Eq, version))
+      ) else (
+        (Name.of_string s, None)
+      )
+    )
+  in
+  let time fn =
+    let t0 = Unix.gettimeofday () in
+    let r =
+      try fn st spec
+      with OpamStd.Sys.Exit(60) ->  (* Timeout; already reported on console *)
+        incr errors;
+        None
+    in
+    let t1 = Unix.gettimeofday () in
+    (t1 -. t0, r)
+  in
+  let opam_time, opam = time select_opam in
+  let zi_time, zi = time select_zi in
+  Fmt.pr "Opam %.2f s -> 0install %.2f s (%.1f times faster)@." opam_time zi_time (opam_time /. zi_time);
+  compare st ~opam ~zi
+
+let () =
+  let t0 = Unix.gettimeofday () in
+  let root = OpamStateConfig.opamroot () in
+  OpamFormatConfig.init ();
+  ignore (OpamStateConfig.load_defaults root);
+  OpamStd.Config.init ();
+  OpamStateConfig.init ();
+  OpamClientConfig.opam_init ();
+  OpamGlobalState.with_ `Lock_none @@ fun gt ->
+  let rt = OpamRepositoryState.load `Lock_none gt in
+  let st = OpamSwitchState.load_virtual gt rt in
+  let t1 = Unix.gettimeofday () in
+  OpamConsole.note "Opam library initialised in %.2f s" (t1 -. t0);
+  (* Some reasonable fixed tests *)
+  test st ["utop"; "ocaml.4.08.1"];
+  test st ["irmin-git"; "ocaml.4.08.1"];
+  test st ["irmin-mirage-git"; "ocaml.4.08.1"];
+  test st ["dune"; "irmin.0.10.0"; "cohttp"; "git"; "ocaml.4.04.2"];
+  test st ["datakit-ci"; "ocaml.4.08.1"];
+  test st ["datakit-ci"; "ocaml.4.07.1"];
+  let available = Lazy.force st.OpamStateTypes.available_packages
+                  |> OpamPackage.Set.to_seq
+                  |> Seq.map OpamPackage.name
+                  |> Name.Set.of_seq |> Name.Set.to_seq
+                  |> Array.of_seq in
+  Fmt.pr "@.-------- Trying some packages at random --------@.";
+  for _ = 0 to 10 do
+    let i = Random.int (Array.length available) in
+    test st ["ocaml"; OpamPackage.Name.to_string available.(i)]
+  done;
+  Fmt.pr "@.-------- Trying some random pairs --------@.";
+  for _ = 0 to 10 do
+    let i = Random.int (Array.length available) in
+    let j = Random.int (Array.length available) in
+    test st ["ocaml"; OpamPackage.Name.to_string available.(i); OpamPackage.Name.to_string available.(j)]
+  done;
+  if !errors = 0 then Fmt.pr "@.All tests passed@."
+  else (
+    Fmt.pr "@.%a: %d error(s)@." Fmt.(styled `Red string) "Tests failed" !errors;
+    exit 1
+  )


### PR DESCRIPTION
The new `make test` runs various queries using both the opam and 0install solvers. It checks they agree on whether or not there is a solution, and shows any differences. It tries a few fixed queries, then 10 random packages, then 10 random pairs of packages. If the solvers disagree, it also asks opam to confirm that 0install's solution is valid too. The tests are run from a virtual switch with no installed packages.

![solver](https://user-images.githubusercontent.com/554131/73365859-e7d83f00-42a4-11ea-8903-dc0d73a152dc.png)

The main cause of differences is jbuilder, where 0install may prefer to install the latest "transition" version, forcing an older version of dune to be selected, whereas opam prefers the latest dune and an older jbuilder.