### PR TITLE
Fix handling of conflicts without a version expression

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -163,6 +163,7 @@ let () =
   test st ["dune"; "irmin.0.10.0"; "cohttp"; "git"; "ocaml.4.04.2"];
   test st ["datakit-ci"; "ocaml.4.08.1"];
   test st ["datakit-ci"; "ocaml.4.07.1"];
+  test st ["opam-core.2.0.0~rc"; "ocaml.4.09.0"];
   let available = Lazy.force st.OpamStateTypes.available_packages
                   |> OpamPackage.Set.to_seq
                   |> Seq.map OpamPackage.name


### PR DESCRIPTION
To convert from opam's `conflicts` expressions to 0install's "restricts" feature, we used `OpamFormula.neg` to invert the expression. Unfortunately, this doesn't work when there is no expression because in that case the formula is `Empty` and `OpamFormula.neg _ Empty = Empty`.

Instead, just tag the expression as needing to be inverted later and negate the result after evaluating it.

Reported by @kit-ty-kate.