### PR TITLE
 Evaluate availability expression in `Dir_context`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ let env =
     ~os_family:"debian"
     ~os_distribution:"debian"
     ~os_version:"10"
+    ()
 
 let context =
   Opam_0install.Dir_context.create "/tmp/opam-repository/packages"

--- a/lib/dir_context.mli
+++ b/lib/dir_context.mli
@@ -6,11 +6,14 @@
 include S.CONTEXT
 
 val std_env :
+  ?ocaml_native:bool ->
+  ?sys_ocaml_version:string ->
   arch:string ->
   os:string ->
   os_distribution:string ->
   os_family:string ->
   os_version:string ->
+  unit ->
   (string -> OpamVariable.variable_contents option)
 (** [std_env ~arch ~os ~os_distribution ~os_family ~os_version] is an
     environment function that returns the given values for the standard opam

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -7,10 +7,7 @@ module type CONTEXT = sig
 
   val pp_rejection : rejection Fmt.t
 
-  val load : t -> OpamPackage.t -> OpamFile.OPAM.t
-  (** [load t pkg] loads the opam metadata for [pkg]. *)
-
-  val candidates : t -> OpamPackage.Name.t -> (OpamPackage.Version.t * rejection option) list
+  val candidates : t -> OpamPackage.Name.t -> (OpamPackage.Version.t * (OpamFile.OPAM.t, rejection) result) list
   (** [candidates t name] is the list of available versions of [name], in order
       of decreasing preference. If the user or environment provides additional
       constraints that mean a version should be rejected, include that here too. Rejects

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -11,7 +11,8 @@ module type CONTEXT = sig
   (** [candidates t name] is the list of available versions of [name], in order
       of decreasing preference. If the user or environment provides additional
       constraints that mean a version should be rejected, include that here too. Rejects
-      are only used for generating diagnostics reports. *)
+      are only used for generating diagnostics reports. Candidates whose "availablity" field
+      isn't satisfied must be rejected here. *)
 
   val user_restrictions : t -> OpamPackage.Name.t -> OpamFormula.version_constraint option
   (** [user_restrictions t pkg] is the user's constraint on [pkg], if any. This is just

--- a/lib/switch_context.ml
+++ b/lib/switch_context.ml
@@ -39,8 +39,10 @@ let candidates t name =
     |> List.map (fun v ->
         match user_constraints with
         | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
-          v, Some (UserConstraint (name, Some test))  (* Reject *)
-        | _ -> v, None
+          v, Error (UserConstraint (name, Some test))
+        | _ ->
+          let opam = load t (OpamPackage.create name v) in
+          v, Ok opam
       )
   | None ->
     OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);

--- a/lib/switch_context.ml
+++ b/lib/switch_context.ml
@@ -42,6 +42,7 @@ let candidates t name =
           v, Error (UserConstraint (name, Some test))
         | _ ->
           let opam = load t (OpamPackage.create name v) in
+          (* Note: [OpamStateTypes.available_packages] filters out unavailable packages for us. *)
           v, Ok opam
       )
   | None ->

--- a/test/dump.ml
+++ b/test/dump.ml
@@ -1,6 +1,33 @@
 (* For every package name in the opam repository, solve for that package and
    collect the results in a CSV file. *)
 
+(*
+module Cached_dir_context = struct
+  include Opam_0install.Dir_context
+
+  let cache = Hashtbl.create 10000
+
+  let candidates t name =
+    match Hashtbl.find_opt cache name with
+    | Some x -> x
+    | None ->
+      let r = candidates t name in
+      Hashtbl.add cache name r;
+      r
+end
+
+let env =
+  Opam_0install.Dir_context.std_env
+    ~arch:"x86_64"
+    ~os:"linux"
+    ~os_family:"debian"
+    ~os_distribution:"debian"
+    ~os_version:"10"
+    ()
+
+module Solver = Opam_0install.Solver.Make(Cached_dir_context)
+*)
+
 module Solver = Opam_0install.Solver.Make(Opam_0install.Switch_context)
 module Name = OpamPackage.Name
 
@@ -28,6 +55,7 @@ let dump_slice ~tmpfile ~available ~st proc start finish =
           let name = available.(i) in
           let constraints = OpamPackage.Name.Map.empty in
           let context = Opam_0install.Switch_context.create ~constraints st in
+          (* let context = Opam_0install.Dir_context.create ~constraints ~env "/tmp/opam-repository/packages" in *)
           let t0 = Unix.gettimeofday () in
           let r = Solver.solve context [name] in
           let t1 = Unix.gettimeofday () in


### PR DESCRIPTION
This isn't needed for `Switch_context` because the switch does it for us, but `Dir_context` could return packages with `available: false`.

With this change, running `test/dump.ml` gives the same results for me with both context providers (except for `ocaml-system`, which I left blank for the `Dir_context` test).