### PR TITLE
opam-0install-cudf: Remove the unnecessary dependency towards the opam library

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -52,7 +52,6 @@ the CUDF interface.
  (depends
   fmt
   cmdliner
-  opam-state
   cudf
   (ocaml (>= 4.08.0))
   0install-solver))

--- a/lib-cudf/dune
+++ b/lib-cudf/dune
@@ -1,4 +1,4 @@
 (library
  (name opam_0install_cudf)
  (public_name opam-0install-cudf)
- (libraries cudf opam-state 0install-solver fmt))
+ (libraries cudf 0install-solver fmt))

--- a/lib-cudf/opam_0install_cudf.ml
+++ b/lib-cudf/opam_0install_cudf.ml
@@ -21,8 +21,7 @@ module Context = struct
     let user_constraints = user_restrictions t name in
     match Cudf.lookup_packages t.universe name with
     | [] ->
-        OpamConsole.log "opam-0install-cudf" "Package %S not found!" name;
-        []
+        [] (* Package not found *)
     | versions ->
         List.fast_sort (fun pkg1 pkg2 -> compare (pkg2.Cudf.version : int) pkg1.Cudf.version) versions
         |> List.map (fun pkg ->

--- a/opam-0install-cudf.opam
+++ b/opam-0install-cudf.opam
@@ -22,7 +22,6 @@ depends: [
   "dune" {>= "2.0"}
   "fmt"
   "cmdliner"
-  "opam-state"
   "cudf"
   "ocaml" {>= "4.08.0"}
   "0install-solver"


### PR DESCRIPTION
It seems the only reason there was still a dependency on the `opam-state` library was because `OpamConsole.log` was called. However I don't think this is necessary, ~the case where it is needed should not happen anyway~ EDIT: it happens but I don't see why we'd need to log this.