### PR TITLE
Allow to tag packages as recommended or restricted when giving them to the solver

### DIFF
--- a/lib-cudf/model.ml
+++ b/lib-cudf/model.ml
@@ -76,9 +76,9 @@ module Make (Context : S.CONTEXT) = struct
       !i
 
   let virtual_impl ~context ~depends () =
-    let depends = depends |> List.map (fun name ->
+    let depends = depends |> List.map (fun (name, importance) ->
         let drole = role context name in
-        { drole; importance = `Essential; restrictions = []}
+        { drole; importance; restrictions = []}
       ) in
     VirtualImpl (fresh_id (), depends)
 

--- a/lib-cudf/model.ml
+++ b/lib-cudf/model.ml
@@ -20,6 +20,8 @@ module Make (Context : S.CONTEXT) = struct
     name : Cudf_types.pkgname;
   }
 
+  type importance = [ `Essential | `Recommended | `Restricts ]
+
   type role =
     | Real of real_role               (* A role is usually an opam package name *)
     | Virtual of int * impl list      (* (int just for sorting) *)
@@ -29,7 +31,7 @@ module Make (Context : S.CONTEXT) = struct
   }
   and dependency = {
     drole : role;
-    importance : [ `Essential | `Recommended | `Restricts ];
+    importance : importance;
     restrictions : restriction list;
   }
   and impl =
@@ -78,6 +80,7 @@ module Make (Context : S.CONTEXT) = struct
   let virtual_impl ~context ~depends () =
     let depends = depends |> List.map (fun (name, importance) ->
         let drole = role context name in
+        let importance = (importance :> importance) in
         { drole; importance; restrictions = []}
       ) in
     VirtualImpl (fresh_id (), depends)
@@ -93,7 +96,7 @@ module Make (Context : S.CONTEXT) = struct
 
   type dep_info = {
     dep_role : Role.t;
-    dep_importance : [ `Essential | `Recommended | `Restricts ];
+    dep_importance : importance;
     dep_required_commands : command_name list;
   }
 

--- a/lib-cudf/model.mli
+++ b/lib-cudf/model.mli
@@ -30,9 +30,13 @@ module Make (Context : S.CONTEXT) : sig
       This is used if the user requests multiple packages on the command line
       (the single [impl] will also be virtual). *)
 
-  val virtual_impl : context:Context.t -> depends:Cudf_types.pkgname list -> unit -> impl
+  val virtual_impl :
+    context:Context.t ->
+    depends:(Cudf_types.pkgname * [`Essential | `Recommended | `Restricts]) list ->
+    unit ->
+    impl
   (** [virtual_impl ~context ~depends] is a virtual package which just depends
       on [depends]. This is used if the user requests multiple packages on the
       command line - each requested package becomes a dependency of the virtual
-      implementation. *)
+      implementation according to their associated requirement tag. *)
 end

--- a/lib-cudf/model.mli
+++ b/lib-cudf/model.mli
@@ -32,7 +32,7 @@ module Make (Context : S.CONTEXT) : sig
 
   val virtual_impl :
     context:Context.t ->
-    depends:(Cudf_types.pkgname * [`Essential | `Recommended | `Restricts]) list ->
+    depends:(Cudf_types.pkgname * [`Essential | `Recommended]) list ->
     unit ->
     impl
   (** [virtual_impl ~context ~depends] is a virtual package which just depends

--- a/lib-cudf/opam_0install_cudf.ml
+++ b/lib-cudf/opam_0install_cudf.ml
@@ -53,11 +53,8 @@ module Input = Model.Make(Context)
 
 let requirements ~context pkgs =
   let role =
-    match pkgs with
-    | [pkg] -> Input.role context pkg
-    | pkgs ->
-        let impl = Input.virtual_impl ~context ~depends:pkgs () in
-        Input.virtual_role [impl]
+    let impl = Input.virtual_impl ~context ~depends:pkgs () in
+    Input.virtual_role [impl]
   in
   { Input.role; command = None }
 

--- a/lib-cudf/opam_0install_cudf.mli
+++ b/lib-cudf/opam_0install_cudf.mli
@@ -10,7 +10,7 @@ val create : constraints:(Cudf_types.pkgname * (Cudf_types.relop * Cudf_types.ve
 
 val solve :
   t ->
-  (Cudf_types.pkgname * [`Essential | `Recommended | `Restricts]) list ->
+  (Cudf_types.pkgname * [`Essential | `Recommended]) list ->
   (selections, diagnostics) result
 (** [solve t packages] finds a compatible set of package versions that
     includes all packages in [packages] according to their requirement tag,

--- a/lib-cudf/opam_0install_cudf.mli
+++ b/lib-cudf/opam_0install_cudf.mli
@@ -8,9 +8,13 @@ val create : constraints:(Cudf_types.pkgname * (Cudf_types.relop * Cudf_types.ve
 (** [create ~constraints universe] is a solver that gets candidates from [universe], filtering them
     using [constraints]. *)
 
-val solve : t -> Cudf_types.pkgname list -> (selections, diagnostics) result
-(** [solve t package_names] finds a compatible set of package versions that
-    includes all packages in [package_names] and their required dependencies. *)
+val solve :
+  t ->
+  (Cudf_types.pkgname * [`Essential | `Recommended | `Restricts]) list ->
+  (selections, diagnostics) result
+(** [solve t packages] finds a compatible set of package versions that
+    includes all packages in [packages] according to their requirement tag,
+    and their required dependencies if needed. *)
 
 val packages_of_result : selections -> (Cudf_types.pkgname * Cudf_types.version) list
 


### PR DESCRIPTION
I seem to have overlooked these tag in my first implementation in https://github.com/talex5/opam-0install-solver/pull/11. However they ended up being really useful for the complete integration in opam.

For example it was previously not possible to allow some packages to be removed if needed when requesting a new package on a switch already used before, such as when using the solver in a desktop environment as default solver.

With this change I believe there shouldn't be anything to prevent users to use it as default solver if they wish to.

This PR is required for the opam integration PR: https://github.com/ocaml/opam/pull/4240